### PR TITLE
#12 - AuditingFields 추출

### DIFF
--- a/src/main/java/org/fastcampus/fastcampusprojectboard/domain/Article.java
+++ b/src/main/java/org/fastcampus/fastcampusprojectboard/domain/Article.java
@@ -23,9 +23,8 @@ import java.util.Set;
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Article {
+public class Article extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,19 +44,6 @@ public class Article {
     @OrderBy("id")
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private final Set<ArticleComment> articleCommentSet = new LinkedHashSet<>();
-
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;    // 생성일시
-    @CreatedBy
-    @Column(nullable = false, length = 100)
-    private String createdBy;           // 생성자
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;   // 수정일시
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private String modifiedBy;          // 수정자
 
     protected Article() {
     }

--- a/src/main/java/org/fastcampus/fastcampusprojectboard/domain/ArticleComment.java
+++ b/src/main/java/org/fastcampus/fastcampusprojectboard/domain/ArticleComment.java
@@ -20,9 +20,8 @@ import java.util.Objects;
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,19 +33,6 @@ public class ArticleComment {
     @Setter
     @Column(nullable = false, length = 500)
     private String content;             // 본문
-
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;    // 생성일시
-    @CreatedBy
-    @Column(nullable = false, length = 100)
-    private String createdBy;           // 생성자
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;   // 수정일시
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private String modifiedBy;          // 수정자
 
     protected ArticleComment() {}
 

--- a/src/main/java/org/fastcampus/fastcampusprojectboard/domain/AuditingFields.java
+++ b/src/main/java/org/fastcampus/fastcampusprojectboard/domain/AuditingFields.java
@@ -1,0 +1,35 @@
+package org.fastcampus.fastcampusprojectboard.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;    // 생성일시
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    private String createdBy;           // 생성자
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;   // 수정일시
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private String modifiedBy;          // 수정자
+}


### PR DESCRIPTION
생성자, 생성일시, 수정자, 수정일시는 반복적으로 엔티티 클래스에 들어가는 요소이며,
도메인과 직접 연관이 없는 요소이므로
추출이 가능하다.

`@MappedSuperclass` 이용하여 상속 방식으로 수정
그 외 `@DateTimeFormat` 요소 추가 및 jpa 옵션 개선